### PR TITLE
Fix 'Orderbook snapshot' API spec response field name from 'prices' to 'price'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,29 +1327,29 @@ GET /v1/orderbook/:symbol
     <span class="s2">"success"</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
     <span class="s2">"asks"</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.4</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.4</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">1.56263218</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10670.3</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10670.3</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.36466977</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10670.4</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10670.4</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.06738009</span>
         <span class="p">}</span>
     <span class="p">],</span>
     <span class="s2">"bids"</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.3</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.3</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.88159988</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.2</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.2</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.5</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10668.9</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10668.9</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.00488286</span>
         <span class="p">}</span>
     <span class="p">],</span>


### PR DESCRIPTION
Fix documentation field name for **Orderbook snapshot** endpoint.

Rename JSON field: "prices"  to "price"

Currently, the API Response Spec for this endpoint is:
`{
    "success": true,
    "asks": [
        {
            "prices": 10669.4,
            "quantity": 1.56263218
        },
        {
            "prices": 10670.3,
            "quantity": 0.36466977
        },
        {
            "prices": 10670.4,
            "quantity": 0.06738009
        }
    ],
    "bids": [
        {
            "prices": 10669.3,
            "quantity": 0.88159988
        },
        {
            "prices": 10669.2,
            "quantity": 0.5
        },
        {
            "prices": 10668.9,
            "quantity": 0.00488286
        }
    ],
    "timestamp": 1564710591905
}`

But the API returns:
`{
    "success": true,
    "asks": [
        {
            "price": 10669.4,
            "quantity": 1.56263218
        },
        {
            "price": 10670.3,
            "quantity": 0.36466977
        },
        {
            "price": 10670.4,
            "quantity": 0.06738009
        }
    ],
    "bids": [
        {
            "price": 10669.3,
            "quantity": 0.88159988
        },
        {
            "price": 10669.2,
            "quantity": 0.5
        },
        {
            "price": 10668.9,
            "quantity": 0.00488286
        }
    ],
    "timestamp": 1564710591905
}`