### PR TITLE
Add 'timestamp' fields unit (seconds or milliseconds) reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,29 +1327,29 @@ GET /v1/orderbook/:symbol
     <span class="s2">"success"</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
     <span class="s2">"asks"</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.4</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.4</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">1.56263218</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10670.3</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10670.3</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.36466977</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10670.4</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10670.4</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.06738009</span>
         <span class="p">}</span>
     <span class="p">],</span>
     <span class="s2">"bids"</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.3</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.3</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.88159988</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10669.2</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10669.2</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.5</span>
         <span class="p">},</span>
         <span class="p">{</span>
-            <span class="s2">"prices"</span><span class="p">:</span> <span class="mf">10668.9</span><span class="p">,</span>
+            <span class="s2">"price"</span><span class="p">:</span> <span class="mf">10668.9</span><span class="p">,</span>
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.00488286</span>
         <span class="p">}</span>
     <span class="p">],</span>

--- a/index.html
+++ b/index.html
@@ -466,19 +466,23 @@ Assume following infomation:</p>
 <tr>
 <th>Key</th>
 <th>Value</th>
+<th>Description</th>
 </tr>
 </thead><tbody>
 <tr>
 <td><code>api_key</code></td>
 <td><code>AbmyVJGUpN064ks5ELjLfA==</code></td>
+<td>The client <code>api_key</code></td>
 </tr>
 <tr>
 <td><code>api_secret</code></td>
 <td><code>QHKRXHPAW1MC9YGZMAT8YDJG2HPR</code></td>
+<td>The client <code>api_secret</code></td>
 </tr>
 <tr>
 <td><code>timestamp</code></td>
 <td><code>1578565539808</code></td>
+<td>Unix epoch time in <code>milliseconds</code></td>
 </tr>
 </tbody></table>
 
@@ -827,8 +831,8 @@ GET /v1/public/token
     <span class="s2">"success"</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
     <span class="s2">"rows"</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1579399877.02"</span><span class="p">,</span>
-            <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1579399877.02"</span><span class="p">,</span>
+            <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1579399877.02"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
+            <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1579399877.02"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
             <span class="s2">"token"</span><span class="p">:</span> <span class="s2">"BTC"</span><span class="p">,</span>
             <span class="s2">"balance_token"</span><span class="p">:</span> <span class="s2">"BTC"</span><span class="p">,</span>
             <span class="s2">"fullname"</span><span class="p">:</span> <span class="s2">"Bitcoin"</span><span class="p">,</span>
@@ -1127,7 +1131,7 @@ GET /v1/order/:oid
             <span class="s2">"order_id"</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span>
             <span class="s2">"executed_price"</span><span class="p">:</span> <span class="mi">123</span><span class="p">,</span>
             <span class="s2">"executed_quantity"</span><span class="p">:</span> <span class="mf">0.05</span><span class="p">,</span>
-            <span class="s2">"executed_timestamp"</span><span class="p">:</span> <span class="s2">"1567382401.000000"</span><span class="p">,</span>
+            <span class="s2">"executed_timestamp"</span><span class="p">:</span> <span class="s2">"1567382401.000000"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
             <span class="s2">"is_maker"</span><span class="p">:</span> <span class="mi">1</span>
         <span class="p">}]</span>
 <span class="p">}</span>
@@ -1163,7 +1167,7 @@ GET /v1/client/order/:client_order_id
 </blockquote>
 <pre class="highlight javascript"><code><span class="p">{</span>
     <span class="s2">"success"</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
-    <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1577349119.33"</span><span class="p">,</span>
+    <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1577349119.33"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
     <span class="s2">"side"</span><span class="p">:</span> <span class="s2">"SELL"</span><span class="p">,</span>
     <span class="s2">"status"</span><span class="p">:</span> <span class="s2">"FILLED"</span><span class="p">,</span>
     <span class="s2">"symbol"</span><span class="p">:</span> <span class="s2">"SPOT_BTC_USDT"</span><span class="p">,</span>
@@ -1188,7 +1192,7 @@ GET /v1/client/order/:client_order_id
             <span class="s2">"order_id"</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span>
             <span class="s2">"executed_price"</span><span class="p">:</span> <span class="mi">123</span><span class="p">,</span>
             <span class="s2">"executed_quantity"</span><span class="p">:</span> <span class="mf">0.05</span><span class="p">,</span>
-            <span class="s2">"executed_timestamp"</span><span class="p">:</span> <span class="s2">"1567382401.000000"</span><span class="p">,</span>
+            <span class="s2">"executed_timestamp"</span><span class="p">:</span> <span class="s2">"1567382401.000000"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
             <span class="s2">"is_maker"</span><span class="p">:</span> <span class="mi">1</span>
         <span class="p">}]</span>
 <span class="p">}</span>
@@ -1243,8 +1247,8 @@ GET /v1/orders
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.0019</span><span class="p">,</span>
             <span class="s2">"amount"</span><span class="p">:</span> <span class="kc">null</span><span class="p">,</span>
             <span class="s2">"executed"</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span>
-            <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1575014255.089"</span><span class="p">,</span>
-            <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1575014255.910"</span><span class="p">,</span>
+            <span class="s2">"created_time"</span><span class="p">:</span> <span class="s2">"1575014255.089"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
+            <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1575014255.910"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
             <span class="s2">"Transactions"</span><span class="p">:</span> <span class="p">[],</span>
             <span class="s2">"average_executed_price"</span><span class="p">:</span> <span class="kc">null</span><span class="p">,</span>
         <span class="p">},</span>
@@ -1353,7 +1357,7 @@ GET /v1/orderbook/:symbol
             <span class="s2">"quantity"</span><span class="p">:</span> <span class="mf">0.00488286</span>
         <span class="p">}</span>
     <span class="p">],</span>
-    <span class="s2">"timestamp"</span><span class="p">:</span> <span class="mi">1564710591905</span>
+    <span class="s2">"timestamp"</span><span class="p">:</span> <span class="mi">1564710591905 <span class="c1">// Unix epoch time in milliseconds</span></span>
 <span class="p">}</span>
 </code></pre>
 <p><strong>Parameters</strong></p>
@@ -1581,7 +1585,7 @@ GET /v2/client/holding
   <span class="nl">success</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span>
   <span class="nx">holding</span><span class="p">:</span> <span class="p">[</span>
     <span class="p">{</span>
-      <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1580794149"</span><span class="p">,</span>
+      <span class="s2">"updated_time"</span><span class="p">:</span> <span class="s2">"1580794149"</span><span class="p">, <span class="c1">// Unix epoch time in seconds</span></span>
       <span class="s2">"token"</span><span class="p">:</span> <span class="s2">"BTC"</span><span class="p">,</span>
       <span class="s2">"holding"</span><span class="p">:</span> <span class="o">-</span><span class="mf">28.000752</span><span class="p">,</span>
       <span class="s2">"frozen"</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span>


### PR DESCRIPTION
This PR adds to multiple places that reference "timestamp" to its represented unit in seconds or milliseconds.